### PR TITLE
Add request referer to global drop

### DIFF
--- a/lib/locomotive/steam/middlewares/renderer.rb
+++ b/lib/locomotive/steam/middlewares/renderer.rb
@@ -98,14 +98,15 @@ module Locomotive::Steam
 
       def _request_liquid_assigns
         {
-          'path'        => request.path,
-          'fullpath'    => request.fullpath,
-          'url'         => request.url,
-          'ip_address'  => request.ip,
-          'post?'       => request.post?,
           'base_url'    => request.base_url,
+          'fullpath'    => request.fullpath,
+          'ip_address'  => request.ip,
+          'mounted_on'  => mounted_on,
+          'path'        => request.path,
+          'post?'       => request.post?,
+          'referer'     => request.referer,
+          'url'         => request.url,
           'user_agent'  => request.user_agent,
-          'mounted_on'  => mounted_on
         }
       end
 


### PR DESCRIPTION
Seems reasonable to have this easily accessible in Liquid without needing to
resort to JS (`document.referrer`).
